### PR TITLE
Add contributors to footer + fix SCSS issue by adding maps 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.35.2",
     "sass-loader": "^12.6.0"
+  },
+  "dependencies": {
+    "@11ty/eleventy-fetch": "^3.0.0"
   }
 }

--- a/src/data/contributors.js
+++ b/src/data/contributors.js
@@ -1,5 +1,5 @@
-const Repo = "mandrasch/11ty-plain-bootstrap5"; // Define the repo to get contributors from
-const Cache = require("@11ty/eleventy-fetch");
+const Repo = "mandrasch/11ty-plain-bootstrap5"; // Change repo to change the contributors. NOTE: REPO MUST BE PUBLIC
+const Cache = require("@11ty/eleventy-fetch"); // Use fetch to get the contributors
 
 module.exports = async function () {
   return await Cache(`https://api.github.com/repos/${Repo}/contributors`, {

--- a/src/data/contributors.js
+++ b/src/data/contributors.js
@@ -1,0 +1,9 @@
+const Repo = "mandrasch/11ty-plain-bootstrap5"; // Define the repo to get contributors from
+const Cache = require("@11ty/eleventy-fetch");
+
+module.exports = async function () {
+  return await Cache(`https://api.github.com/repos/${Repo}/contributors`, {
+    duration: "1w", // 1 week
+    type: "json",
+  });
+};

--- a/src/includes/footer.njk
+++ b/src/includes/footer.njk
@@ -4,4 +4,15 @@
     <a href="https://github.com/mandrasch/11ty-plain-bootstrap5">GitHub</a> ·
     <a href="{{ '/pages/imprint' | url }}">Imprint</a> · <a href="{{ '/pages/privacy' | url }}">Privacy</a>
   </p>
+  <div class="row">
+    <div class="col-12 col-md text-center">
+      Built with &#10084 by
+      <br />
+      {% for contributor in contributors %}
+      <a href="{{ contributor.html_url }}">
+        <img src="{{ contributor.avatar_url }}" class="avatar" />
+      </a>
+      {% endfor %}
+    </div>
+  </div>
 </footer>

--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -38,3 +38,9 @@
     width: 100%;
   }
 }
+.avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  object-fit: cover;
+}

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -12,6 +12,7 @@
 // 3. Include remainder of required Bootstrap stylesheets
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/maps";
 @import "~bootstrap/scss/utilities";
 
 // 4. Include any optional Bootstrap components as you like


### PR DESCRIPTION
Hello!

I've added in the ability to pull contributors via a github repository as I've done on the edited version I'm using over at [Codhead Club](https://github.com/codheadclub) for the website. It'll display all the contributors in the footer in a row. 

I have also added in the new `@import "~bootstrap/scss/maps";` as referenced [here](https://getbootstrap.com/docs/5.2/migration/#new-_mapsscss) and [here](https://github.com/twbs/bootstrap/issues/36785#issuecomment-1189969247) as it was causing issues when building the template for production. Adding the maps reference resolves this issue.

The template was a useful base to build my 11ty site, so thanks and I hope these contributions as helpful for maintainance / enhancements. 